### PR TITLE
Add visible recording processing states

### DIFF
--- a/docs/mockups/processing-modal.html
+++ b/docs/mockups/processing-modal.html
@@ -1,0 +1,711 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>NeuroVox Processing Modal Mockup</title>
+    <style>
+        :root {
+            color-scheme: dark;
+            --background: #161619;
+            --surface: #202024;
+            --surface-raised: #28282e;
+            --surface-soft: #303037;
+            --border: rgba(255, 255, 255, 0.09);
+            --text: #f2f1f5;
+            --text-muted: #aaa7b2;
+            --accent: #9b87f5;
+            --accent-bright: #b8a9ff;
+            --accent-soft: rgba(155, 135, 245, 0.14);
+            --success: #73d7b2;
+            --danger: #f16f75;
+            --shadow: 0 28px 80px rgba(0, 0, 0, 0.52), 0 4px 18px rgba(0, 0, 0, 0.28);
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            min-height: 100vh;
+            margin: 0;
+            overflow: hidden;
+            color: var(--text);
+            background: var(--background);
+            font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        }
+
+        button {
+            font: inherit;
+        }
+
+        .app {
+            display: grid;
+            grid-template-columns: 250px 1fr;
+            min-height: 100vh;
+            background:
+                radial-gradient(circle at 72% 18%, rgba(155, 135, 245, 0.06), transparent 34%),
+                var(--background);
+        }
+
+        .sidebar {
+            padding: 22px 16px;
+            border-right: 1px solid var(--border);
+            background: #1b1b1f;
+        }
+
+        .vault-name {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            margin-bottom: 30px;
+            font-size: 13px;
+            font-weight: 650;
+        }
+
+        .vault-mark {
+            width: 27px;
+            height: 27px;
+            border-radius: 8px;
+            background: linear-gradient(145deg, var(--accent-bright), #705bdd);
+            box-shadow: 0 8px 22px rgba(112, 91, 221, 0.25);
+        }
+
+        .nav-label {
+            margin: 22px 8px 8px;
+            color: #77747f;
+            font-size: 10px;
+            font-weight: 700;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+        }
+
+        .nav-item {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            height: 34px;
+            padding: 0 10px;
+            border-radius: 7px;
+            color: #aaa7b2;
+            font-size: 12px;
+        }
+
+        .nav-item.active {
+            color: #e8e6ed;
+            background: #29282e;
+        }
+
+        .nav-icon {
+            width: 13px;
+            height: 13px;
+            border: 1.5px solid currentColor;
+            border-radius: 3px;
+            opacity: 0.7;
+        }
+
+        .editor {
+            max-width: 850px;
+            width: 100%;
+            margin: 0 auto;
+            padding: 74px 70px;
+        }
+
+        .editor h1 {
+            margin: 0 0 28px;
+            font-family: Georgia, "Times New Roman", serif;
+            font-size: 36px;
+            font-weight: 500;
+            letter-spacing: -0.025em;
+        }
+
+        .editor p {
+            max-width: 650px;
+            margin: 0 0 16px;
+            color: #97949e;
+            font-family: Georgia, "Times New Roman", serif;
+            font-size: 17px;
+            line-height: 1.75;
+        }
+
+        .overlay {
+            position: fixed;
+            inset: 0;
+            display: grid;
+            place-items: center;
+            padding: 24px;
+            background: rgba(8, 8, 10, 0.62);
+            backdrop-filter: blur(7px);
+            transition: opacity 240ms ease;
+        }
+
+        .overlay.is-hidden {
+            pointer-events: none;
+            opacity: 0;
+        }
+
+        .modal {
+            position: relative;
+            width: min(390px, 100%);
+            min-height: 390px;
+            overflow: hidden;
+            border: 1px solid var(--border);
+            border-radius: 18px;
+            background:
+                radial-gradient(circle at 50% 0%, rgba(155, 135, 245, 0.09), transparent 38%),
+                var(--surface);
+            box-shadow: var(--shadow);
+        }
+
+        .modal::before {
+            content: "";
+            position: absolute;
+            inset: 0 0 auto;
+            height: 1px;
+            background: linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.2), transparent);
+        }
+
+        .screen {
+            position: absolute;
+            inset: 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 42px 36px 36px;
+            opacity: 0;
+            transform: translateY(10px) scale(0.985);
+            pointer-events: none;
+            transition: opacity 280ms ease, transform 320ms cubic-bezier(0.2, 0.8, 0.2, 1);
+        }
+
+        .modal[data-view="recording"] .recording-screen,
+        .modal[data-view="working"] .working-screen,
+        .modal[data-view="done"] .done-screen {
+            z-index: 2;
+            opacity: 1;
+            transform: translateY(0) scale(1);
+            pointer-events: auto;
+        }
+
+        .eyebrow {
+            margin-bottom: 18px;
+            color: var(--text-muted);
+            font-size: 11px;
+            font-weight: 700;
+            letter-spacing: 0.14em;
+            text-transform: uppercase;
+        }
+
+        .timer {
+            margin-bottom: 34px;
+            font-variant-numeric: tabular-nums;
+            font-size: 52px;
+            font-weight: 650;
+            letter-spacing: -0.045em;
+        }
+
+        .wave {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 5px;
+            height: 48px;
+            margin-bottom: 34px;
+        }
+
+        .wave span {
+            width: 5px;
+            height: 14px;
+            border-radius: 10px;
+            background: linear-gradient(var(--accent-bright), var(--accent));
+            animation: recording-wave 1.15s ease-in-out infinite;
+        }
+
+        .wave span:nth-child(2) { animation-delay: -0.88s; }
+        .wave span:nth-child(3) { animation-delay: -0.56s; }
+        .wave span:nth-child(4) { animation-delay: -0.28s; }
+        .wave span:nth-child(5) { animation-delay: -0.72s; }
+
+        @keyframes recording-wave {
+            0%, 100% { height: 12px; opacity: 0.65; }
+            50% { height: 42px; opacity: 1; }
+        }
+
+        .controls {
+            display: flex;
+            gap: 18px;
+        }
+
+        .round-button {
+            display: grid;
+            width: 54px;
+            height: 54px;
+            place-items: center;
+            border: 0;
+            border-radius: 50%;
+            color: white;
+            background: var(--surface-soft);
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.06), 0 8px 20px rgba(0, 0, 0, 0.2);
+            cursor: pointer;
+            transition: transform 160ms ease, filter 160ms ease;
+        }
+
+        .round-button:hover {
+            filter: brightness(1.12);
+            transform: translateY(-2px);
+        }
+
+        .round-button:active {
+            transform: translateY(0) scale(0.96);
+        }
+
+        .stop-button {
+            background: var(--danger);
+        }
+
+        .pause-icon {
+            display: flex;
+            gap: 4px;
+        }
+
+        .pause-icon span {
+            width: 4px;
+            height: 17px;
+            border-radius: 2px;
+            background: currentColor;
+        }
+
+        .stop-icon {
+            width: 16px;
+            height: 16px;
+            border-radius: 3px;
+            background: currentColor;
+        }
+
+        .spinner-wrap {
+            position: relative;
+            display: grid;
+            width: 112px;
+            height: 112px;
+            margin-bottom: 28px;
+            place-items: center;
+        }
+
+        .spinner-glow {
+            position: absolute;
+            inset: 20px;
+            border-radius: 50%;
+            background: var(--accent-soft);
+            filter: blur(13px);
+            animation: breathe 1.8s ease-in-out infinite;
+        }
+
+        .spinner {
+            position: absolute;
+            inset: 7px;
+            border: 2px solid rgba(255, 255, 255, 0.07);
+            border-top-color: var(--accent-bright);
+            border-right-color: rgba(155, 135, 245, 0.45);
+            border-radius: 50%;
+            animation: spin 1.05s linear infinite;
+        }
+
+        .spinner-inner {
+            position: absolute;
+            inset: 19px;
+            border: 1px solid rgba(255, 255, 255, 0.08);
+            border-bottom-color: rgba(184, 169, 255, 0.58);
+            border-radius: 50%;
+            animation: spin-reverse 1.6s linear infinite;
+        }
+
+        .spinner-core {
+            position: relative;
+            display: grid;
+            width: 58px;
+            height: 58px;
+            place-items: center;
+            border-radius: 50%;
+            background: var(--surface);
+            box-shadow: 0 0 18px 9px var(--surface);
+        }
+
+        .mini-wave {
+            display: flex;
+            align-items: center;
+            gap: 3px;
+            height: 22px;
+        }
+
+        .mini-wave span {
+            width: 3px;
+            height: 8px;
+            border-radius: 4px;
+            background: var(--accent-bright);
+            animation: mini-wave 760ms ease-in-out infinite alternate;
+        }
+
+        .mini-wave span:nth-child(2) { animation-delay: -240ms; }
+        .mini-wave span:nth-child(3) { animation-delay: -480ms; }
+
+        .processing-mark {
+            display: none;
+            color: var(--accent-bright);
+            font-size: 26px;
+            line-height: 1;
+            animation: mark-pulse 1.3s ease-in-out infinite;
+        }
+
+        .modal[data-stage="processing"] .mini-wave {
+            display: none;
+        }
+
+        .modal[data-stage="processing"] .processing-mark {
+            display: block;
+        }
+
+        @keyframes spin { to { transform: rotate(360deg); } }
+        @keyframes spin-reverse { to { transform: rotate(-360deg); } }
+        @keyframes breathe { 50% { opacity: 0.55; transform: scale(1.18); } }
+        @keyframes mini-wave { to { height: 21px; } }
+        @keyframes mark-pulse { 50% { opacity: 0.55; transform: scale(0.9) rotate(8deg); } }
+
+        .stage-title {
+            margin: 0 0 9px;
+            font-size: 24px;
+            font-weight: 660;
+            letter-spacing: -0.025em;
+        }
+
+        .stage-description {
+            min-height: 40px;
+            max-width: 280px;
+            margin: 0 0 31px;
+            color: var(--text-muted);
+            font-size: 13px;
+            line-height: 1.55;
+            text-align: center;
+        }
+
+        .stages {
+            display: grid;
+            grid-template-columns: 1fr 44px 1fr;
+            align-items: center;
+            width: 100%;
+            padding: 0 8px;
+        }
+
+        .stage-step {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            color: #77747f;
+            font-size: 11px;
+            font-weight: 650;
+            transition: color 240ms ease;
+        }
+
+        .stage-step:last-child {
+            justify-content: flex-end;
+        }
+
+        .stage-dot {
+            display: grid;
+            width: 21px;
+            height: 21px;
+            place-items: center;
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 50%;
+            font-size: 10px;
+            transition: color 240ms ease, background 240ms ease, border-color 240ms ease;
+        }
+
+        .stage-line {
+            position: relative;
+            height: 1px;
+            overflow: hidden;
+            background: rgba(255, 255, 255, 0.09);
+        }
+
+        .stage-line::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            background: linear-gradient(90deg, transparent, var(--accent-bright), transparent);
+            transform: translateX(-100%);
+            animation: line-travel 1.45s ease-in-out infinite;
+        }
+
+        @keyframes line-travel { to { transform: translateX(100%); } }
+
+        .modal[data-stage="transcribing"] .step-transcribing,
+        .modal[data-stage="processing"] .step-processing {
+            color: var(--text);
+        }
+
+        .modal[data-stage="transcribing"] .step-transcribing .stage-dot,
+        .modal[data-stage="processing"] .step-processing .stage-dot {
+            color: var(--accent-bright);
+            border-color: rgba(155, 135, 245, 0.55);
+            background: var(--accent-soft);
+            box-shadow: 0 0 0 4px rgba(155, 135, 245, 0.06);
+        }
+
+        .modal[data-stage="processing"] .step-transcribing {
+            color: var(--success);
+        }
+
+        .modal[data-stage="processing"] .step-transcribing .stage-dot {
+            color: #10271f;
+            border-color: transparent;
+            background: var(--success);
+        }
+
+        .done-mark {
+            display: grid;
+            width: 86px;
+            height: 86px;
+            margin-bottom: 27px;
+            place-items: center;
+            border: 1px solid rgba(115, 215, 178, 0.3);
+            border-radius: 50%;
+            color: var(--success);
+            background: rgba(115, 215, 178, 0.09);
+            font-size: 38px;
+            box-shadow: 0 0 0 12px rgba(115, 215, 178, 0.035);
+        }
+
+        .done-screen p {
+            margin: 0;
+            color: var(--text-muted);
+            font-size: 13px;
+        }
+
+        .prototype-toolbar {
+            position: fixed;
+            right: 18px;
+            bottom: 18px;
+            z-index: 10;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            padding: 8px 10px 8px 13px;
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            color: #a9a6b0;
+            background: rgba(32, 32, 36, 0.88);
+            box-shadow: 0 10px 30px rgba(0, 0, 0, 0.28);
+            backdrop-filter: blur(10px);
+            font-size: 11px;
+        }
+
+        .replay-button {
+            padding: 7px 10px;
+            border: 0;
+            border-radius: 7px;
+            color: var(--text);
+            background: var(--surface-soft);
+            cursor: pointer;
+        }
+
+        .replay-button:hover {
+            background: #3a3941;
+        }
+
+        @media (max-width: 700px) {
+            .app {
+                display: block;
+            }
+
+            .sidebar {
+                display: none;
+            }
+
+            .editor {
+                padding: 48px 28px;
+            }
+
+            .modal {
+                min-height: 380px;
+            }
+
+            .prototype-toolbar span {
+                display: none;
+            }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after {
+                scroll-behavior: auto !important;
+                animation-duration: 0.001ms !important;
+                animation-iteration-count: 1 !important;
+                transition-duration: 0.001ms !important;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main class="app" aria-hidden="true">
+        <aside class="sidebar">
+            <div class="vault-name"><span class="vault-mark"></span>Research Vault</div>
+            <div class="nav-label">Notes</div>
+            <div class="nav-item active"><span class="nav-icon"></span>Product ideas</div>
+            <div class="nav-item"><span class="nav-icon"></span>Meeting notes</div>
+            <div class="nav-item"><span class="nav-icon"></span>Voice memos</div>
+            <div class="nav-label">Recent</div>
+            <div class="nav-item"><span class="nav-icon"></span>July 21</div>
+            <div class="nav-item"><span class="nav-icon"></span>Project outline</div>
+        </aside>
+        <article class="editor">
+            <h1>Product ideas</h1>
+            <p>The voice workflow should feel immediate and dependable. Every pause needs a visible reason, especially after the user has finished speaking.</p>
+            <p>Processing should feel like a continuation of recording—not an interruption or a frozen interface.</p>
+        </article>
+    </main>
+
+    <div class="overlay" id="overlay">
+        <section class="modal" id="modal" data-view="recording" data-stage="transcribing" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+            <div class="screen recording-screen">
+                <div class="eyebrow" id="modal-title">Recording</div>
+                <div class="timer" id="timer">00:18</div>
+                <div class="wave" aria-hidden="true">
+                    <span></span><span></span><span></span><span></span><span></span>
+                </div>
+                <div class="controls">
+                    <button class="round-button" id="pause-button" type="button" aria-label="Pause recording">
+                        <span class="pause-icon" aria-hidden="true"><span></span><span></span></span>
+                    </button>
+                    <button class="round-button stop-button" id="stop-button" type="button" aria-label="Stop recording">
+                        <span class="stop-icon" aria-hidden="true"></span>
+                    </button>
+                </div>
+            </div>
+
+            <div class="screen working-screen" aria-live="polite" aria-atomic="true">
+                <div class="spinner-wrap" aria-hidden="true">
+                    <div class="spinner-glow"></div>
+                    <div class="spinner"></div>
+                    <div class="spinner-inner"></div>
+                    <div class="spinner-core">
+                        <div class="mini-wave"><span></span><span></span><span></span></div>
+                        <div class="processing-mark">✦</div>
+                    </div>
+                </div>
+                <h2 class="stage-title" id="stage-title">Transcribing</h2>
+                <p class="stage-description" id="stage-description">Turning your recording into text.</p>
+                <div class="stages" aria-label="Processing progress">
+                    <div class="stage-step step-transcribing">
+                        <span class="stage-dot" id="transcribing-dot">1</span>
+                        <span>Transcribing</span>
+                    </div>
+                    <div class="stage-line"></div>
+                    <div class="stage-step step-processing">
+                        <span class="stage-dot">2</span>
+                        <span>Processing</span>
+                    </div>
+                </div>
+            </div>
+
+            <div class="screen done-screen" aria-live="polite">
+                <div class="done-mark" aria-hidden="true">✓</div>
+                <h2 class="stage-title">Added to your note</h2>
+                <p>Your recording is ready.</p>
+            </div>
+        </section>
+    </div>
+
+    <div class="prototype-toolbar">
+        <span>Interactive mockup</span>
+        <button class="replay-button" id="replay-button" type="button">Replay</button>
+    </div>
+
+    <script>
+        const modal = document.querySelector('#modal');
+        const overlay = document.querySelector('#overlay');
+        const stopButton = document.querySelector('#stop-button');
+        const pauseButton = document.querySelector('#pause-button');
+        const replayButton = document.querySelector('#replay-button');
+        const timer = document.querySelector('#timer');
+        const stageTitle = document.querySelector('#stage-title');
+        const stageDescription = document.querySelector('#stage-description');
+        const transcribingDot = document.querySelector('#transcribing-dot');
+
+        let seconds = 18;
+        let paused = false;
+        let timers = [];
+        let recordingInterval;
+
+        function formatTime(value) {
+            const minutes = Math.floor(value / 60).toString().padStart(2, '0');
+            const remaining = (value % 60).toString().padStart(2, '0');
+            return `${minutes}:${remaining}`;
+        }
+
+        function startClock() {
+            window.clearInterval(recordingInterval);
+            recordingInterval = window.setInterval(() => {
+                if (!paused && modal.dataset.view === 'recording') {
+                    seconds += 1;
+                    timer.textContent = formatTime(seconds);
+                }
+            }, 1000);
+        }
+
+        function clearSequence() {
+            timers.forEach(window.clearTimeout);
+            timers = [];
+        }
+
+        function showRecording() {
+            clearSequence();
+            overlay.classList.remove('is-hidden');
+            modal.dataset.view = 'recording';
+            modal.dataset.stage = 'transcribing';
+            stageTitle.textContent = 'Transcribing';
+            stageDescription.textContent = 'Turning your recording into text.';
+            transcribingDot.textContent = '1';
+            paused = false;
+            seconds = 18;
+            timer.textContent = formatTime(seconds);
+            pauseButton.setAttribute('aria-label', 'Pause recording');
+            startClock();
+        }
+
+        function runProcessingSequence() {
+            if (modal.dataset.view !== 'recording') return;
+
+            window.clearInterval(recordingInterval);
+            modal.dataset.stage = 'transcribing';
+            modal.dataset.view = 'working';
+
+            timers.push(window.setTimeout(() => {
+                modal.dataset.stage = 'processing';
+                stageTitle.textContent = 'Processing your note';
+                stageDescription.textContent = 'Applying your preferences and adding the result to Obsidian.';
+                transcribingDot.textContent = '✓';
+            }, 2800));
+
+            timers.push(window.setTimeout(() => {
+                modal.dataset.view = 'done';
+            }, 5600));
+
+            timers.push(window.setTimeout(() => {
+                overlay.classList.add('is-hidden');
+            }, 6800));
+        }
+
+        stopButton.addEventListener('click', runProcessingSequence);
+
+        pauseButton.addEventListener('click', () => {
+            paused = !paused;
+            pauseButton.setAttribute('aria-label', paused ? 'Resume recording' : 'Pause recording');
+            pauseButton.style.opacity = paused ? '0.55' : '1';
+        });
+
+        replayButton.addEventListener('click', showRecording);
+
+        startClock();
+    </script>
+</body>
+</html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -451,35 +451,30 @@ export default class NeuroVoxPlugin extends Plugin {
             
             this.modalInstance = new TimerModal(this);
             this.modalInstance.onStop = async (result: Blob | string) => {
-                try {
-                    if (typeof result === 'string') {
-                        // Streaming mode - transcription already done
-                        await this.recordingProcessor.processStreamingResult(
-                            result,
-                            activeFile,
-                            activeView.editor.getCursor()
-                        );
-                    } else {
-                        // Legacy mode - need to transcribe
-                        const adapter = this.aiAdapters.get(this.settings.transcriptionProvider);
-                        if (!adapter) {
-                            throw new Error(`Transcription provider ${this.settings.transcriptionProvider} not found`);
-                        }
-
-                        // Moonshine doesn't require an API key (local model)
-                        if (this.settings.transcriptionProvider !== AIProvider.Moonshine && !adapter.getApiKey()) {
-                            throw new Error(`API key not set for ${this.settings.transcriptionProvider}`);
-                        }
-
-                        await this.recordingProcessor.processRecording(
-                            result,
-                            activeFile,
-                            activeView.editor.getCursor()
-                        );
+                if (typeof result === 'string') {
+                    // Streaming mode - transcription already done
+                    await this.recordingProcessor.processStreamingResult(
+                        result,
+                        activeFile,
+                        activeView.editor.getCursor()
+                    );
+                } else {
+                    // Legacy mode - need to transcribe
+                    const adapter = this.aiAdapters.get(this.settings.transcriptionProvider);
+                    if (!adapter) {
+                        throw new Error(`Transcription provider ${this.settings.transcriptionProvider} not found`);
                     }
-                } catch (error) {
-                    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-                    new Notice(`❌ Failed to process recording: ${errorMessage}`);
+
+                    // Moonshine doesn't require an API key (local model)
+                    if (this.settings.transcriptionProvider !== AIProvider.Moonshine && !adapter.getApiKey()) {
+                        throw new Error(`API key not set for ${this.settings.transcriptionProvider}`);
+                    }
+
+                    await this.recordingProcessor.processRecording(
+                        result,
+                        activeFile,
+                        activeView.editor.getCursor()
+                    );
                 }
             };
             

--- a/src/modals/TimerModal.ts
+++ b/src/modals/TimerModal.ts
@@ -25,6 +25,7 @@ export class TimerModal extends Modal {
     private intervalId: number | null = null;
     private seconds: number = 0;
     private isClosing: boolean = false;
+    private isStopping: boolean = false;
     private currentState: RecordingState = 'inactive';
     private streamingService: StreamingTranscriptionService | null = null;
     private deviceDetection: DeviceDetection;
@@ -122,7 +123,7 @@ export class TimerModal extends Modal {
      * Handles all close attempts, ensuring proper cleanup and save prompts
      */
     private async requestClose(): Promise<void> {
-        if (this.isClosing) return;
+        if (this.isClosing || this.isStopping) return;
         this.isClosing = true;
 
         if (this.currentState === 'recording' || this.currentState === 'paused') {
@@ -158,6 +159,7 @@ export class TimerModal extends Modal {
 
             const { contentEl } = this;
             contentEl.empty();
+            this.modalEl.addClass('neurovox-timer-modal-shell');
             contentEl.addClass('neurovox-timer-modal');
 
             // Add mobile-specific class
@@ -382,6 +384,13 @@ export class TimerModal extends Modal {
      * Handles stop button click
      */
     private async handleStop(): Promise<void> {
+        if (this.isStopping) return;
+
+        this.isStopping = true;
+        this.pauseTimer();
+        this.currentState = 'stopped';
+        this.ui.showProcessing('transcribing');
+
         try {
             this.stopRotationMonitor();
 
@@ -397,8 +406,6 @@ export class TimerModal extends Modal {
             if (!this.streamingService) {
                 throw new Error('Streaming service not initialized');
             }
-
-            new Notice('Finishing transcription...');
 
             if (finalBlob && finalBlob.size > 0) {
                 if (this.streamingService.hasReceivedChunks()) {
@@ -418,16 +425,19 @@ export class TimerModal extends Modal {
                 throw new Error('No transcription result received');
             }
 
-            // Close recording modal first
-            this.cleanup();
-            super.close();
-
-            // Always save the recording
+            // Keep the modal visible while post-processing and note insertion complete.
+            this.ui.showProcessing('processing');
             if (this.onStop) {
                 await this.onStop(result);
             }
+
+            this.ui.showComplete();
+            await new Promise(resolve => window.setTimeout(resolve, 450));
+
+            this.cleanup();
+            super.close();
         } catch (error) {
-            this.handleError('Failed to stop recording', error);
+            this.handleError('Failed to finish recording', error);
         }
     }
 
@@ -536,6 +546,7 @@ export class TimerModal extends Modal {
         } finally {
             // Reset states
             this.currentState = 'inactive';
+            this.isStopping = false;
             this.seconds = 0;
             this.isClosing = false;
             this.chunkIndex = 0;

--- a/src/ui/RecordingUI.ts
+++ b/src/ui/RecordingUI.ts
@@ -2,6 +2,7 @@ import { setIcon } from 'obsidian';
 import { TouchableButton } from './TouchableButton';
 
 export type RecordingState = 'recording' | 'paused' | 'stopped' | 'inactive';
+export type ProcessingStage = 'transcribing' | 'processing';
 
 export interface RecordingUIHandlers {
     onPause: () => void;
@@ -13,10 +14,19 @@ export interface RecordingUIHandlers {
  * 📱 Enhanced with debouncing and state management for better mobile stability
  */
 export class RecordingUI {
+    private recordingView: HTMLElement;
+    private processingView: HTMLElement;
     private timerText: HTMLElement;
     private pauseButton: TouchableButton;
     private stopButton: TouchableButton;
     private waveContainer: HTMLElement;
+    private processingTitle: HTMLElement;
+    private processingDescription: HTMLElement;
+    private transcribingStep: HTMLElement;
+    private processingStep: HTMLElement;
+    private transcribingDot: HTMLElement;
+    private processingIcon: HTMLElement;
+    private completeIcon: HTMLElement;
     private currentState: RecordingState = 'inactive';
 
     constructor(
@@ -33,9 +43,24 @@ export class RecordingUI {
         // Add touch event handlers to container
         this.setupTouchHandlers();
         
+        this.createRecordingView();
+        this.createProcessingView();
+        this.showRecording();
+    }
+
+    private createRecordingView(): void {
+        this.recordingView = this.container.createDiv({
+            cls: 'neurovox-recording-view'
+        });
+
+        this.recordingView.createDiv({
+            cls: 'neurovox-recording-label',
+            text: 'Recording'
+        });
+
         this.createTimerDisplay();
-        this.createControls();
         this.createWaveform();
+        this.createControls();
     }
 
     /**
@@ -66,14 +91,14 @@ export class RecordingUI {
     }
 
     private createTimerDisplay(): void {
-        this.timerText = this.container.createDiv({
+        this.timerText = this.recordingView.createDiv({
             cls: 'neurovox-timer-display',
             text: '00:00'
         });
     }
 
     private createControls(): void {
-        const controls = this.container.createDiv({
+        const controls = this.recordingView.createDiv({
             cls: 'neurovox-timer-controls'
         });
 
@@ -99,7 +124,7 @@ export class RecordingUI {
     }
 
     private createWaveform(): void {
-        this.waveContainer = this.container.createDiv({
+        this.waveContainer = this.recordingView.createDiv({
             cls: 'neurovox-audio-wave'
         });
         
@@ -108,6 +133,123 @@ export class RecordingUI {
                 cls: 'neurovox-wave-bar'
             });
         }
+    }
+
+    private createProcessingView(): void {
+        this.processingView = this.container.createDiv({
+            cls: 'neurovox-processing-view'
+        });
+        this.processingView.setAttribute('aria-live', 'polite');
+        this.processingView.setAttribute('aria-atomic', 'true');
+
+        const spinnerWrap = this.processingView.createDiv({
+            cls: 'neurovox-processing-spinner-wrap'
+        });
+        spinnerWrap.setAttribute('aria-hidden', 'true');
+        spinnerWrap.createDiv({ cls: 'neurovox-processing-spinner-glow' });
+        spinnerWrap.createDiv({ cls: 'neurovox-processing-spinner' });
+        spinnerWrap.createDiv({ cls: 'neurovox-processing-spinner-inner' });
+
+        const aperture = spinnerWrap.createDiv({
+            cls: 'neurovox-processing-aperture'
+        });
+        const miniWave = aperture.createDiv({
+            cls: 'neurovox-processing-mini-wave'
+        });
+        for (let i = 0; i < 3; i++) {
+            miniWave.createSpan();
+        }
+
+        this.processingIcon = aperture.createDiv({
+            cls: 'neurovox-processing-stage-icon'
+        });
+        setIcon(this.processingIcon, 'sparkles');
+
+        this.completeIcon = aperture.createDiv({
+            cls: 'neurovox-processing-complete-icon'
+        });
+        setIcon(this.completeIcon, 'check');
+
+        this.processingTitle = this.processingView.createEl('h2', {
+            cls: 'neurovox-processing-title',
+            text: 'Transcribing'
+        });
+        this.processingDescription = this.processingView.createEl('p', {
+            cls: 'neurovox-processing-description',
+            text: 'Turning your recording into text.'
+        });
+
+        const stages = this.processingView.createDiv({
+            cls: 'neurovox-processing-stages'
+        });
+        stages.setAttribute('aria-label', 'Processing progress');
+
+        this.transcribingStep = stages.createDiv({
+            cls: 'neurovox-processing-step is-transcribing'
+        });
+        this.transcribingDot = this.transcribingStep.createSpan({
+            cls: 'neurovox-processing-step-dot',
+            text: '1'
+        });
+        this.transcribingStep.createSpan({ text: 'Transcribing' });
+
+        stages.createDiv({ cls: 'neurovox-processing-step-line' });
+
+        this.processingStep = stages.createDiv({
+            cls: 'neurovox-processing-step is-processing'
+        });
+        this.processingStep.createSpan({
+            cls: 'neurovox-processing-step-dot',
+            text: '2'
+        });
+        this.processingStep.createSpan({ text: 'Processing' });
+    }
+
+    public showRecording(): void {
+        this.container.removeClass('is-processing-view', 'is-complete-view');
+        this.container.addClass('is-recording-view');
+        this.container.removeAttribute('data-processing-stage');
+        this.pauseButton.buttonEl.disabled = false;
+        this.stopButton.buttonEl.disabled = false;
+    }
+
+    public showProcessing(stage: ProcessingStage): void {
+        this.container.removeClass('is-recording-view', 'is-complete-view');
+        this.container.addClass('is-processing-view');
+        this.container.setAttribute('data-processing-stage', stage);
+        this.pauseButton.buttonEl.disabled = true;
+        this.stopButton.buttonEl.disabled = true;
+
+        if (stage === 'transcribing') {
+            this.processingTitle.setText('Transcribing');
+            this.processingDescription.setText('Turning your recording into text.');
+            this.transcribingDot.setText('1');
+            this.transcribingStep.removeClass('is-complete');
+            this.transcribingStep.addClass('is-active');
+            this.processingStep.removeClass('is-active');
+        } else {
+            this.processingTitle.setText('Processing your note');
+            this.processingDescription.setText(
+                'Applying your preferences and adding the result to your note.'
+            );
+            this.transcribingDot.setText('✓');
+            this.transcribingStep.removeClass('is-active');
+            this.transcribingStep.addClass('is-complete');
+            this.processingStep.addClass('is-active');
+        }
+    }
+
+    public showComplete(): void {
+        this.container.removeClass('is-recording-view', 'is-processing-view');
+        this.container.addClass('is-complete-view');
+        this.container.setAttribute('data-processing-stage', 'complete');
+        this.processingTitle.setText('Added to your note');
+        this.processingDescription.setText('Your recording is ready.');
+        this.transcribingDot.setText('✓');
+        this.transcribingStep.removeClass('is-active');
+        this.transcribingStep.addClass('is-complete');
+        this.processingStep.removeClass('is-active');
+        this.processingStep.addClass('is-complete');
     }
 
     public updateTimer(seconds: number, maxDuration: number, warningThreshold: number): void {
@@ -122,6 +264,10 @@ export class RecordingUI {
 
     public updateState(state: RecordingState): void {
         this.currentState = state;
+
+        if (state === 'recording' || state === 'paused') {
+            this.showRecording();
+        }
         
         const states = ['is-recording', 'is-paused', 'is-stopped', 'is-inactive'];
         states.forEach(cls => this.waveContainer.removeClass(cls));

--- a/styles.css
+++ b/styles.css
@@ -44,28 +44,77 @@
 /************************************
  * MODAL STYLES
  ************************************/
-.neurovox-timer-modal {
-    background-color: var(--background-primary);
+.modal.neurovox-timer-modal-shell {
+    padding: 0;
+    border: 1px solid var(--background-modifier-border);
     border-radius: var(--neurovox-border-radius-lg);
+    background:
+        radial-gradient(
+            circle at 50% 0%,
+            color-mix(in srgb, var(--interactive-accent) 10%, transparent),
+            transparent 42%
+        ),
+        var(--background-primary);
     box-shadow: var(--shadow-l);
     overflow: hidden;
 }
 
+.neurovox-timer-modal {
+    padding: 0;
+    background: transparent;
+    border-radius: inherit;
+    box-shadow: none;
+    overflow: hidden;
+}
+
 .neurovox-timer-content {
+    position: relative;
+    min-height: 390px;
+    padding: 0;
+    margin: 0 auto;
+    width: min(390px, 100%);
+    max-width: 400px;
+    overflow: hidden;
+}
+
+.neurovox-recording-view,
+.neurovox-processing-view {
+    position: absolute;
+    inset: 0;
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: var(--neurovox-spacing-lg);
-    padding: var(--neurovox-spacing-lg);
-    margin: 0 auto;
-    width: 100%;
-    max-width: 400px;
+    justify-content: center;
+    padding: 40px 34px 34px;
+    opacity: 0;
+    transform: translateY(8px) scale(0.985);
+    pointer-events: none;
+    transition:
+        opacity 0.28s ease,
+        transform 0.32s cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+.neurovox-timer-content.is-recording-view .neurovox-recording-view,
+.neurovox-timer-content.is-processing-view .neurovox-processing-view,
+.neurovox-timer-content.is-complete-view .neurovox-processing-view {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    pointer-events: auto;
+}
+
+.neurovox-recording-label {
+    margin-bottom: 18px;
+    color: var(--text-muted);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
 }
 
 /* Mobile-specific modal adjustments */
 .neurovox-timer-modal.is-mobile .neurovox-timer-content {
-    padding: var(--neurovox-spacing-md);
-    gap: var(--neurovox-spacing-md);
+    min-height: 380px;
+    padding: 0;
     max-width: 100%;
 }
 
@@ -77,7 +126,7 @@
     line-height: 1;
     letter-spacing: 0.1em;
     text-align: center;
-    margin: 0;
+    margin: 0 0 30px;
     white-space: nowrap;
     transition: color var(--neurovox-transition-normal) ease;
 }
@@ -256,7 +305,7 @@
     justify-content: center;
     gap: var(--neurovox-spacing-xs);
     height: calc(var(--neurovox-wave-height) + var(--neurovox-spacing-md));
-    margin: 0;
+    margin: 0 0 28px;
     padding: var(--neurovox-spacing-sm);
     touch-action: none;
     pointer-events: none;
@@ -299,6 +348,263 @@
 .neurovox-audio-wave.is-stopped .neurovox-wave-bar {
     animation: none;
     transform: scaleY(0.3);
+}
+
+/************************************
+ * RECORDING PROCESSING STATES
+ ************************************/
+.neurovox-processing-spinner-wrap {
+    position: relative;
+    display: grid;
+    width: 112px;
+    height: 112px;
+    margin-bottom: 27px;
+    place-items: center;
+}
+
+.neurovox-processing-spinner-glow {
+    position: absolute;
+    inset: 20px;
+    border-radius: 50%;
+    background: color-mix(in srgb, var(--interactive-accent) 16%, transparent);
+    filter: blur(13px);
+    animation: neurovox-processing-breathe 1.8s ease-in-out infinite;
+}
+
+.neurovox-processing-spinner,
+.neurovox-processing-spinner-inner {
+    position: absolute;
+    border-radius: 50%;
+}
+
+.neurovox-processing-spinner {
+    inset: 7px;
+    border: 2px solid var(--background-modifier-border);
+    border-top-color: var(--interactive-accent);
+    border-right-color: color-mix(in srgb, var(--interactive-accent) 48%, transparent);
+    animation: neurovox-processing-spin 1.05s linear infinite;
+}
+
+.neurovox-processing-spinner-inner {
+    inset: 19px;
+    border: 1px solid var(--background-modifier-border);
+    border-bottom-color: var(--interactive-accent-hover);
+    animation: neurovox-processing-spin-reverse 1.6s linear infinite;
+}
+
+.neurovox-processing-aperture {
+    position: relative;
+    display: grid;
+    width: 58px;
+    height: 58px;
+    place-items: center;
+    border-radius: 50%;
+    background: var(--background-primary);
+    box-shadow: 0 0 18px 9px var(--background-primary);
+    transition:
+        width 0.28s ease,
+        height 0.28s ease,
+        color 0.28s ease,
+        background-color 0.28s ease;
+}
+
+.neurovox-processing-mini-wave {
+    display: flex;
+    align-items: center;
+    gap: 3px;
+    height: 22px;
+}
+
+.neurovox-processing-mini-wave span {
+    width: 3px;
+    height: 8px;
+    border-radius: 4px;
+    background: var(--interactive-accent);
+    animation: neurovox-processing-mini-wave 0.76s ease-in-out infinite alternate;
+}
+
+.neurovox-processing-mini-wave span:nth-child(2) {
+    animation-delay: -0.24s;
+}
+
+.neurovox-processing-mini-wave span:nth-child(3) {
+    animation-delay: -0.48s;
+}
+
+.neurovox-processing-stage-icon,
+.neurovox-processing-complete-icon {
+    display: none;
+    color: var(--interactive-accent);
+}
+
+.neurovox-processing-stage-icon svg {
+    width: 25px;
+    height: 25px;
+    animation: neurovox-processing-mark-pulse 1.3s ease-in-out infinite;
+}
+
+.neurovox-processing-complete-icon svg {
+    width: 32px;
+    height: 32px;
+    stroke-width: 2.4;
+}
+
+.neurovox-timer-content[data-processing-stage="processing"] .neurovox-processing-mini-wave {
+    display: none;
+}
+
+.neurovox-timer-content[data-processing-stage="processing"] .neurovox-processing-stage-icon {
+    display: flex;
+}
+
+.neurovox-processing-title {
+    margin: 0 0 8px;
+    color: var(--text-normal);
+    font-size: 1.5rem;
+    font-weight: 650;
+    letter-spacing: -0.025em;
+}
+
+.neurovox-processing-description {
+    min-height: 40px;
+    max-width: 285px;
+    margin: 0 0 30px;
+    color: var(--text-muted);
+    font-size: 0.82rem;
+    line-height: 1.55;
+    text-align: center;
+}
+
+.neurovox-processing-stages {
+    display: grid;
+    grid-template-columns: 1fr 44px 1fr;
+    align-items: center;
+    width: 100%;
+    padding: 0 8px;
+    transition: opacity 0.22s ease;
+}
+
+.neurovox-processing-step {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-faint);
+    font-size: 0.7rem;
+    font-weight: 650;
+    transition: color 0.24s ease;
+}
+
+.neurovox-processing-step:last-child {
+    justify-content: flex-end;
+}
+
+.neurovox-processing-step-dot {
+    display: grid;
+    flex: 0 0 auto;
+    width: 21px;
+    height: 21px;
+    place-items: center;
+    border: 1px solid var(--background-modifier-border);
+    border-radius: 50%;
+    font-size: 0.62rem;
+    transition:
+        color 0.24s ease,
+        background-color 0.24s ease,
+        border-color 0.24s ease,
+        box-shadow 0.24s ease;
+}
+
+.neurovox-processing-step.is-active {
+    color: var(--text-normal);
+}
+
+.neurovox-processing-step.is-active .neurovox-processing-step-dot {
+    color: var(--interactive-accent);
+    border-color: var(--interactive-accent);
+    background: color-mix(in srgb, var(--interactive-accent) 13%, transparent);
+    box-shadow: 0 0 0 4px color-mix(in srgb, var(--interactive-accent) 6%, transparent);
+}
+
+.neurovox-processing-step.is-complete {
+    color: var(--color-green);
+}
+
+.neurovox-processing-step.is-complete .neurovox-processing-step-dot {
+    color: var(--background-primary);
+    border-color: var(--color-green);
+    background: var(--color-green);
+}
+
+.neurovox-processing-step-line {
+    position: relative;
+    height: 1px;
+    overflow: hidden;
+    background: var(--background-modifier-border);
+}
+
+.neurovox-processing-step-line::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, transparent, var(--interactive-accent), transparent);
+    transform: translateX(-100%);
+    animation: neurovox-processing-line-travel 1.45s ease-in-out infinite;
+}
+
+.neurovox-timer-content.is-complete-view .neurovox-processing-spinner,
+.neurovox-timer-content.is-complete-view .neurovox-processing-spinner-inner {
+    opacity: 0;
+    animation: none;
+}
+
+.neurovox-timer-content.is-complete-view .neurovox-processing-spinner-glow {
+    background: color-mix(in srgb, var(--color-green) 18%, transparent);
+}
+
+.neurovox-timer-content.is-complete-view .neurovox-processing-aperture {
+    width: 76px;
+    height: 76px;
+    color: var(--color-green);
+    background: color-mix(in srgb, var(--color-green) 10%, transparent);
+    box-shadow: 0 0 0 12px color-mix(in srgb, var(--color-green) 4%, transparent);
+}
+
+.neurovox-timer-content.is-complete-view .neurovox-processing-mini-wave,
+.neurovox-timer-content.is-complete-view .neurovox-processing-stage-icon {
+    display: none;
+}
+
+.neurovox-timer-content.is-complete-view .neurovox-processing-complete-icon {
+    display: flex;
+    color: var(--color-green);
+}
+
+.neurovox-timer-content.is-complete-view .neurovox-processing-stages {
+    opacity: 0;
+}
+
+@keyframes neurovox-processing-spin {
+    to { transform: rotate(360deg); }
+}
+
+@keyframes neurovox-processing-spin-reverse {
+    to { transform: rotate(-360deg); }
+}
+
+@keyframes neurovox-processing-breathe {
+    50% { opacity: 0.55; transform: scale(1.18); }
+}
+
+@keyframes neurovox-processing-mini-wave {
+    to { height: 21px; }
+}
+
+@keyframes neurovox-processing-mark-pulse {
+    50% { opacity: 0.55; transform: scale(0.9) rotate(8deg); }
+}
+
+@keyframes neurovox-processing-line-travel {
+    to { transform: translateX(100%); }
 }
 
 /************************************
@@ -654,6 +960,20 @@
     .neurovox-audio-wave.is-recording .neurovox-wave-bar {
         animation: none;
         transform: scaleY(0.5);
+    }
+
+    .neurovox-processing-spinner,
+    .neurovox-processing-spinner-inner,
+    .neurovox-processing-spinner-glow,
+    .neurovox-processing-mini-wave span,
+    .neurovox-processing-stage-icon svg,
+    .neurovox-processing-step-line::after {
+        animation: none;
+    }
+
+    .neurovox-recording-view,
+    .neurovox-processing-view {
+        transition: none;
     }
 }
 


### PR DESCRIPTION
## Summary

- redesign the recording modal to use a cleaner, theme-aware Obsidian presentation
- show distinct transcribing and processing stages after recording stops
- keep the modal open until post-processing and note insertion finish
- guard against duplicate stop and close actions during processing
- include the approved interactive HTML mockup

## Why

The recording modal previously appeared frozen after Stop, then disappeared while additional processing continued without feedback. The new flow makes each asynchronous stage visible and keeps the modal lifecycle aligned with the actual work.

## Validation

- `npm run build`
- `npm test` (8 passing)
